### PR TITLE
Implement session report API contract for #28

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ packages = [
   "quota_core",
   "quota_core.adapters",
   "quota_core.dashboard",
+  "quota_core.session",
 ]
 
 [tool.setuptools.package-data]

--- a/quota_core/adapters/claude.py
+++ b/quota_core/adapters/claude.py
@@ -18,8 +18,12 @@ from quota_core.snapshot import (
 WINDOW_SECONDS = {
     "five_hour": 5 * 3600,
     "seven_day": 7 * 24 * 3600,
+    "current_session": 5 * 3600,
+    "current_week": 7 * 24 * 3600,
+    "current_week_sonnet": 7 * 24 * 3600,
 }
 MAX_LOCAL_SCAN_FILE_BYTES = 50 * 1024 * 1024
+VALID_CACHE_STATES = {"live", "cached", "stale", "unknown"}
 
 
 def normalize_claude_quota(payload: dict[str, Any]) -> NormalizedSnapshot:
@@ -31,10 +35,11 @@ def normalize_claude_quota(payload: dict[str, Any]) -> NormalizedSnapshot:
         return NormalizedSnapshot(source="claude", sampled_at=sampled_at, errors=(str(error),))
 
     windows: dict[str, SnapshotWindow] = {}
-    for window_name, window_seconds in WINDOW_SECONDS.items():
+    for window_name, default_window_seconds in WINDOW_SECONDS.items():
         raw_window = payload.get(window_name)
         if not isinstance(raw_window, dict):
             continue
+        window_seconds = int(raw_window.get("window_seconds") or default_window_seconds)
         resets_at = _optional_int(raw_window.get("resets_at"))
         window_start = resets_at - window_seconds if resets_at is not None else None
         window_end = min(sampled_at, resets_at) if sampled_at and resets_at is not None else sampled_at or resets_at
@@ -43,6 +48,7 @@ def normalize_claude_quota(payload: dict[str, Any]) -> NormalizedSnapshot:
         runtime_requests = int(raw_window.get("runtime_requests") or 0)
         by_project = _project_aggregates(raw_window.get("by_project", {}), total_tokens)
         runtime_by_project = _project_aggregates(raw_window.get("runtime_by_project", {}), runtime_total)
+        cache_state = _cache_state(raw_window, payload)
         windows[window_name] = SnapshotWindow(
             window_start=window_start,
             window_end=window_end,
@@ -58,8 +64,8 @@ def normalize_claude_quota(payload: dict[str, Any]) -> NormalizedSnapshot:
                 by_project=runtime_by_project,
                 by_model=_model_aggregates(runtime_by_project, runtime_total),
             ),
-            cache_state="live",
-            stale=False,
+            cache_state=cache_state,  # type: ignore[arg-type]
+            stale=cache_state == "stale",
         )
     return NormalizedSnapshot(source="claude", sampled_at=sampled_at, windows=windows)
 
@@ -171,6 +177,15 @@ def _project_aggregates(raw: Any, total_tokens: int) -> dict[str, AggregateBreak
             model_requests=model_requests,
         )
     return finalize_project_aggregates(aggregates, total_tokens)
+
+
+def _cache_state(raw_window: dict[str, Any], payload: dict[str, Any]) -> str:
+    state = raw_window.get("cache_state") or payload.get("cache_state")
+    if state in VALID_CACHE_STATES:
+        return str(state)
+    if raw_window.get("stale") or payload.get("stale"):
+        return "stale"
+    return "live"
 
 
 def _model_aggregates(projects: dict[str, AggregateBreakdown], total_tokens: int) -> dict[str, AggregateBreakdown]:

--- a/quota_core/adapters/codex.py
+++ b/quota_core/adapters/codex.py
@@ -30,6 +30,7 @@ def normalize_codex_quota(payload: dict[str, Any]) -> NormalizedSnapshot:
         return NormalizedSnapshot(source="codex", sampled_at=sampled_at, errors=(str(error),))
 
     windows: dict[str, SnapshotWindow] = {}
+    cache_state = _cache_state(payload)
     for window_name, window_seconds in WINDOW_SECONDS.items():
         raw_window = payload.get(window_name)
         if not isinstance(raw_window, dict):
@@ -56,10 +57,21 @@ def normalize_codex_quota(payload: dict[str, Any]) -> NormalizedSnapshot:
                 by_project=runtime_by_project,
                 by_model=_model_aggregates(runtime_by_project, runtime_total),
             ),
-            cache_state="live",
-            stale=False,
+            cache_state=cache_state,
+            stale=cache_state == "stale",
         )
-    return NormalizedSnapshot(source="codex", sampled_at=sampled_at, windows=windows)
+    warnings = ()
+    if cache_state == "stale":
+        warnings = ("codex rate-limit telemetry is stale",)
+    elif cache_state == "cached":
+        warnings = ("codex rate-limit telemetry is cached",)
+    return NormalizedSnapshot(source="codex", sampled_at=sampled_at, windows=windows, warnings=warnings)
+
+def _cache_state(payload: dict[str, Any]) -> str:
+    state = payload.get("cache_state")
+    if state in {"live", "cached", "stale", "unknown"}:
+        return str(state)
+    return "stale" if payload.get("stale") else "live"
 
 
 def scan_codex_local(config: ProviderConfig, sampled_at: int) -> NormalizedSnapshot:

--- a/quota_core/dashboard/app.py
+++ b/quota_core/dashboard/app.py
@@ -1,15 +1,16 @@
-"""FastAPI dashboard app factory skeleton."""
+"""FastAPI dashboard app factory."""
 
 from __future__ import annotations
 
+from typing import Any, Callable
+
 from quota_core.session import build_empty_session_report
 
+SessionReportProvider = Callable[..., dict[str, Any]]
 
-def create_app():
-    """Create the dashboard app.
 
-    FastAPI wiring will be implemented when dashboard extraction begins.
-    """
+def create_app(*, claude_session_report_provider: SessionReportProvider | None = None):
+    """Create the dashboard app."""
 
     try:
         from fastapi import FastAPI
@@ -24,6 +25,8 @@ def create_app():
 
     @app.get("/api/claude_session_report")
     def claude_session_report(window: str | None = None, since: str | None = None, redaction: str | None = None):
+        if claude_session_report_provider is not None:
+            return claude_session_report_provider(window=window, since=since, redaction=redaction)
         return build_empty_session_report(window=window, since=since, redaction=redaction)
 
     return app

--- a/quota_core/dashboard/app.py
+++ b/quota_core/dashboard/app.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from quota_core.session import build_empty_session_report
+
 
 def create_app():
     """Create the dashboard app.
@@ -19,5 +21,9 @@ def create_app():
     @app.get("/")
     def index():
         return {"status": "quota_core dashboard skeleton"}
+
+    @app.get("/api/claude_session_report")
+    def claude_session_report(window: str | None = None, since: str | None = None, redaction: str | None = None):
+        return build_empty_session_report(window=window, since=since, redaction=redaction)
 
     return app

--- a/quota_core/dashboard/components.py
+++ b/quota_core/dashboard/components.py
@@ -21,6 +21,7 @@ def dashboard_overview(snapshots: list[NormalizedSnapshot]) -> str:
         overall_status(providers),
         runtime_usage_report(providers),
         provider_panels(providers),
+        claude_session_panel(providers),
         time_series_panel(providers),
         quota_history_panel(providers),
         detail_windows(providers),
@@ -185,6 +186,80 @@ def usage_window_card(item: DashboardWindow) -> str:
         f'{project_rows(window.by_project, window.total_tokens, max_rows=6)}'
         '</article>'
     )
+
+
+def claude_session_panel(providers: tuple[ProviderDashboard, ...]) -> str:
+    provider = next((item for item in providers if item.source == "claude"), None)
+    if provider is None or not isinstance(provider.snapshot.history, dict):
+        return ""
+    report = provider.snapshot.history.get("claude_session_report")
+    if not isinstance(report, dict):
+        return ""
+    totals = report.get("totals", {}) if isinstance(report.get("totals"), dict) else {}
+    window = report.get("window", {}) if isinstance(report.get("window"), dict) else {}
+    blocks = [
+        session_metric("Total", compact_number(int(totals.get("total_tokens") or 0))),
+        session_metric("Input", compact_number(int(totals.get("input_tokens") or 0))),
+        session_metric("Output", compact_number(int(totals.get("output_tokens") or 0))),
+        session_metric("Cache Read", compact_number(int(totals.get("cache_read_input_tokens") or 0))),
+        session_metric("Cache Create", compact_number(int(totals.get("cache_creation_input_tokens") or 0))),
+        session_metric("Cache Hit", f'{float(totals.get("cache_hit_pct") or 0):.1f}%'),
+    ]
+    sections = [
+        f'<div class="session-metrics">{"".join(blocks)}</div>',
+        f'<p class="panel-note">window: {html.escape(str(window.get("name") or "unknown"))} · {html.escape(str(report.get("cache_state") or "unknown"))}</p>',
+        session_rows("Projects", report.get("by_project", [])),
+        session_rows("Subagents", report.get("by_subagent", [])),
+        session_rows("Skills", report.get("by_skill", [])),
+        session_rows("Slash Commands", report.get("by_slash_command", [])),
+        expensive_prompt_rows(report.get("expensive_prompts", [])),
+        cache_break_rows(report.get("cache_breaks", [])),
+    ]
+    return panel("Claude Sessions", '<div class="session-grid">' + "".join(section for section in sections if section) + "</div>", status_badge(str(report.get("cache_state") or "unknown")))
+
+
+def session_metric(label: str, value: str) -> str:
+    return f'<div class="session-metric"><span>{html.escape(label)}</span><strong>{html.escape(value)}</strong></div>'
+
+
+def session_rows(title: str, rows: object) -> str:
+    if not isinstance(rows, list) or not rows:
+        return ""
+    items = []
+    for row in rows[:6]:
+        if not isinstance(row, dict):
+            continue
+        name = str(row.get("display_name") or row.get("name") or "unknown")
+        share = float(row.get("share_pct") or 0)
+        tokens = compact_number(int(row.get("total_tokens") or 0))
+        items.append(f'<li><span>{html.escape(name)}</span><strong>{share:.1f}% · {html.escape(tokens)}</strong></li>')
+    return f'<article class="session-card"><h3>{html.escape(title)}</h3><ol class="runtime-project-list">{"".join(items)}</ol></article>' if items else ""
+
+
+def expensive_prompt_rows(rows: object) -> str:
+    if not isinstance(rows, list) or not rows:
+        return ""
+    items = []
+    for row in rows[:5]:
+        if not isinstance(row, dict):
+            continue
+        preview = str(row.get("prompt_preview") or row.get("prompt_hash") or "redacted")
+        tokens = compact_number(int(row.get("total_tokens") or 0))
+        items.append(f'<li><span>{html.escape(preview)}</span><strong>{html.escape(tokens)}</strong></li>')
+    return f'<article class="session-card session-card-wide"><h3>Expensive Prompts</h3><ol class="runtime-project-list">{"".join(items)}</ol></article>' if items else ""
+
+
+def cache_break_rows(rows: object) -> str:
+    if not isinstance(rows, list) or not rows:
+        return ""
+    items = []
+    for row in rows[:5]:
+        if not isinstance(row, dict):
+            continue
+        reason = str(row.get("reason") or "cache break")
+        tokens = compact_number(int(row.get("tokens") or 0))
+        items.append(f'<li><span>{html.escape(reason)}</span><strong>{html.escape(tokens)}</strong></li>')
+    return f'<article class="session-card session-card-wide"><h3>Cache Breaks</h3><ol class="runtime-project-list">{"".join(items)}</ol></article>' if items else ""
 
 
 def time_series_panel(providers: tuple[ProviderDashboard, ...]) -> str:
@@ -592,7 +667,15 @@ def provider_title(source: str, *, upper: bool = False) -> str:
 
 
 def short_window_label(name: str) -> str:
-    return "5시간" if name == "five_hour" else "7일" if name == "seven_day" else "현재" if name == "current_quota" else window_label(name)
+    labels = {
+        "five_hour": "5시간",
+        "seven_day": "7일",
+        "current_quota": "현재",
+        "current_session": "현재 세션",
+        "current_week": "이번 주",
+        "current_week_sonnet": "이번 주 Sonnet",
+    }
+    return labels.get(name, window_label(name))
 
 
 def runtime_window_label(name: str) -> str:
@@ -791,6 +874,13 @@ main { max-width:1400px; margin:0 auto; padding:20px 24px; }
 .empty-list { margin:6px 0 0; color:var(--muted); font-size:11px; }
 .usage-grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(260px,1fr)); gap:20px; margin-top:8px; }
 .usage-card > strong { display:block; margin-bottom:8px; font-size:20px; color:#fff; }
+.session-grid { display:grid; grid-template-columns:repeat(4,minmax(0,1fr)); gap:14px; }
+.session-metrics { grid-column:1 / -1; display:grid; grid-template-columns:repeat(6,minmax(0,1fr)); gap:10px; }
+.session-metric, .session-card { background:var(--card2); border:1px solid var(--border-soft); border-radius:8px; padding:10px; min-width:0; }
+.session-metric span { display:block; color:var(--muted); font-size:11px; }
+.session-metric strong { display:block; margin-top:3px; color:#fffaf1; font-size:16px; }
+.session-card h3 { margin:0 0 8px; color:#fffaf1; font-size:12px; }
+.session-card-wide { grid-column:span 2; }
 .timeline-grid { display:grid; grid-template-columns:repeat(3,minmax(0,1fr)); gap:16px; }
 .timeline-card { background:var(--card2); border:1px solid var(--border); border-radius:8px; padding:14px; min-width:0; overflow:hidden; box-shadow:inset 0 1px 0 rgba(255,255,255,.025); }
 .timeline-card h3 { margin:0; color:#fffaf1; font-size:12px; }
@@ -827,6 +917,6 @@ dd { margin:2px 0 0; color:#fffaf1; font-weight:650; overflow-wrap:anywhere; }
 .limit-watch { background:rgba(244,184,96,.15); color:#f4b860; }
 .limit-limited { background:rgba(251,113,133,.16); color:#fb7185; }
 .limit-unknown { background:rgba(148,163,184,.15); color:#94a3b8; }
-@media (max-width: 980px) { .overview-grid, .runtime-grid, .detail-grid, .usage-grid, .timeline-grid { grid-template-columns:1fr; } .runtime-windows, .qc-quota-split { grid-template-columns:1fr; } }
+@media (max-width: 980px) { .overview-grid, .runtime-grid, .detail-grid, .usage-grid, .timeline-grid, .session-grid, .session-metrics { grid-template-columns:1fr; } .runtime-windows, .qc-quota-split { grid-template-columns:1fr; } .session-card-wide { grid-column:auto; } }
 @media (max-width: 640px) { header { padding:14px 16px; } main { padding:16px; } .project-list li, .timeline-projects li { grid-template-columns:minmax(0,1fr); } .project-list strong { text-align:left; } .mini-sparkline { display:none; } dl { grid-template-columns:1fr; } }
 """.strip()

--- a/quota_core/dashboard/view_model.py
+++ b/quota_core/dashboard/view_model.py
@@ -118,7 +118,7 @@ def _dashboard_window(name: str, window: SnapshotWindow) -> DashboardWindow:
         kind = "usage"
     else:
         kind = "local"
-    role: WindowRole = "weekly" if name == "seven_day" else "short" if name in {"five_hour", "current_quota", "today"} else "detail"
+    role: WindowRole = "weekly" if name in {"seven_day", "current_week", "current_week_sonnet"} else "short" if name in {"five_hour", "current_quota", "current_session", "today"} else "detail"
     return DashboardWindow(name=name, window=window, kind=kind, role=role)
 
 
@@ -126,16 +126,16 @@ def _comparison_window_names(windows: dict[str, DashboardWindow]) -> tuple[str, 
     short_name = next(
         (
             name
-            for name in ("five_hour", "current_quota", "today")
+            for name in ("current_session", "five_hour", "current_quota", "today")
             if name in windows and _is_report_window(windows[name])
         ),
         None,
     )
-    has_week = "seven_day" in windows and windows["seven_day"].is_quota
-    if short_name and has_week:
-        return (short_name, "seven_day")
-    if has_week:
-        return ("seven_day",)
+    week_name = next((name for name in ("current_week", "seven_day") if name in windows and windows[name].is_quota), None)
+    if short_name and week_name:
+        return (short_name, week_name)
+    if week_name:
+        return (week_name,)
     return (short_name,) if short_name else ()
 
 
@@ -144,7 +144,7 @@ def _is_report_window(window: DashboardWindow) -> bool:
 
 
 def _primary_window(windows: tuple[DashboardWindow, ...]) -> DashboardWindow | None:
-    quota_windows = [window for window in windows if window.is_quota and window.name in {"five_hour", "current_quota", "seven_day", "today"}]
+    quota_windows = [window for window in windows if window.is_quota and window.name in {"current_session", "current_week", "current_week_sonnet", "five_hour", "current_quota", "seven_day", "today"}]
     if quota_windows:
         return max(quota_windows, key=lambda item: item.window.utilization)
     for window in windows:

--- a/quota_core/session/__init__.py
+++ b/quota_core/session/__init__.py
@@ -1,0 +1,19 @@
+"""Public Claude session analytics contract helpers."""
+
+from .report import (
+    SessionReportQuery,
+    SessionReportWindow,
+    build_empty_session_report,
+    build_session_report,
+    normalize_session_report_query,
+    validate_session_report_dict,
+)
+
+__all__ = [
+    "SessionReportQuery",
+    "SessionReportWindow",
+    "build_empty_session_report",
+    "build_session_report",
+    "normalize_session_report_query",
+    "validate_session_report_dict",
+]

--- a/quota_core/session/__init__.py
+++ b/quota_core/session/__init__.py
@@ -1,5 +1,6 @@
 """Public Claude session analytics contract helpers."""
 
+from .claude import analyze_claude_sessions
 from .report import (
     SessionReportQuery,
     SessionReportWindow,
@@ -10,6 +11,7 @@ from .report import (
 )
 
 __all__ = [
+    "analyze_claude_sessions",
     "SessionReportQuery",
     "SessionReportWindow",
     "build_empty_session_report",

--- a/quota_core/session/claude.py
+++ b/quota_core/session/claude.py
@@ -1,0 +1,510 @@
+"""Claude transcript session analytics parser."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass, field
+from datetime import datetime
+import hashlib
+import json
+from pathlib import Path
+import re
+import time
+from typing import Any, Callable, Iterable
+
+from quota_core.adapters.projects import normalize_project_name
+from quota_core.session.report import SessionReportQuery, build_session_report, normalize_session_report_query
+
+MAX_FILE_BYTES = 50 * 1024 * 1024
+ACTIVE_GAP_SECONDS = 300
+
+Usage = dict[str, int]
+ProjectNormalizer = Callable[[object], str]
+
+
+@dataclass
+class Aggregate:
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read_input_tokens: int = 0
+    cache_creation_input_tokens: int = 0
+    api_calls: int = 0
+    models: dict[str, int] = field(default_factory=dict)
+
+    @property
+    def total_tokens(self) -> int:
+        return self.input_tokens + self.output_tokens + self.cache_read_input_tokens + self.cache_creation_input_tokens
+
+    def add(self, usage: Usage, model: str) -> None:
+        self.input_tokens += usage["input_tokens"]
+        self.output_tokens += usage["output_tokens"]
+        self.cache_read_input_tokens += usage["cache_read_input_tokens"]
+        self.cache_creation_input_tokens += usage["cache_creation_input_tokens"]
+        self.api_calls += 1
+        if model:
+            self.models[model] = self.models.get(model, 0) + usage_total(usage)
+
+
+@dataclass
+class PromptContext:
+    text: str = ""
+    slash_command: str | None = None
+    skill: str | None = None
+    subagent_type: str | None = None
+    timestamp: int | None = None
+
+
+def analyze_claude_sessions(
+    transcript_roots: Iterable[str | Path],
+    *,
+    window: str | None = None,
+    since: str | None = None,
+    redaction: str | None = None,
+    now: int | None = None,
+    quota_windows: dict[str, Any] | None = None,
+    max_file_bytes: int = MAX_FILE_BYTES,
+    active_gap_seconds: int = ACTIVE_GAP_SECONDS,
+    project_normalizer: ProjectNormalizer = normalize_project_name,
+    quota_scanner_total_tokens: int | None = None,
+) -> dict[str, Any]:
+    """Return normalized Claude session analytics from local JSONL transcripts."""
+
+    generated_at = int(time.time()) if now is None else int(now)
+    query = normalize_session_report_query(
+        window=window,
+        since=since,
+        redaction=redaction,
+        now=generated_at,
+        quota_windows=quota_windows,
+    )
+    scanner = ClaudeSessionScanner(
+        transcript_roots=tuple(Path(root).expanduser() for root in transcript_roots),
+        query=query,
+        generated_at=generated_at,
+        max_file_bytes=max_file_bytes,
+        active_gap_seconds=active_gap_seconds,
+        project_normalizer=project_normalizer,
+        quota_scanner_total_tokens=quota_scanner_total_tokens,
+    )
+    return scanner.scan()
+
+
+class ClaudeSessionScanner:
+    def __init__(
+        self,
+        *,
+        transcript_roots: tuple[Path, ...],
+        query: SessionReportQuery,
+        generated_at: int,
+        max_file_bytes: int,
+        active_gap_seconds: int,
+        project_normalizer: ProjectNormalizer,
+        quota_scanner_total_tokens: int | None,
+    ) -> None:
+        self.transcript_roots = transcript_roots
+        self.query = query
+        self.generated_at = generated_at
+        self.max_file_bytes = max_file_bytes
+        self.active_gap_seconds = active_gap_seconds
+        self.project_normalizer = project_normalizer
+        self.quota_scanner_total_tokens = quota_scanner_total_tokens
+        self.totals = Aggregate()
+        self.by_project: dict[str, Aggregate] = defaultdict(Aggregate)
+        self.by_model: dict[str, Aggregate] = defaultdict(Aggregate)
+        self.by_subagent: dict[str, Aggregate] = defaultdict(Aggregate)
+        self.by_skill: dict[str, Aggregate] = defaultdict(Aggregate)
+        self.by_slash_command: dict[str, Aggregate] = defaultdict(Aggregate)
+        self.runtime_by_class: dict[str, Aggregate] = defaultdict(Aggregate)
+        self.expensive_prompts: list[dict[str, Any]] = []
+        self.cache_breaks: list[dict[str, Any]] = []
+        self.seen_api_keys: set[str] = set()
+        self.duplicate_records = 0
+        self.skipped_oversized_files = 0
+        self.skipped_unparseable_timestamps = 0
+        self.malformed_json_records = 0
+        self.timestamps: list[int] = []
+        self.warnings: list[str] = []
+
+    def scan(self) -> dict[str, Any]:
+        for root in self.transcript_roots:
+            self._scan_root(root)
+        self._finalize_warnings()
+        return build_session_report(
+            query=self.query,
+            generated_at=self.generated_at,
+            totals=self._totals(),
+            by_project=self._rows(self.by_project),
+            by_model=self._rows(self.by_model),
+            by_subagent=self._rows(self.by_subagent),
+            by_skill=self._rows(self.by_skill),
+            by_slash_command=self._rows(self.by_slash_command),
+            expensive_prompts=sorted(self.expensive_prompts, key=lambda row: -int(row["total_tokens"]))[:20],
+            cache_breaks=sorted(self.cache_breaks, key=lambda row: -int(row["tokens"]))[:20],
+            runtime_attribution=self._runtime_attribution(),
+            reconciliation=self._reconciliation(),
+            warnings=self.warnings,
+        )
+
+    def _scan_root(self, root: Path) -> None:
+        if not root.exists():
+            self.warnings.append("transcript root does not exist")
+            return
+        transcripts = [root] if root.is_file() else sorted(root.rglob("*.jsonl"))
+        for transcript in transcripts:
+            self._scan_file(root if root.is_dir() else root.parent, transcript)
+
+    def _scan_file(self, root: Path, transcript: Path) -> None:
+        try:
+            if transcript.stat().st_size > self.max_file_bytes:
+                self.skipped_oversized_files += 1
+                return
+        except OSError:
+            return
+        project = self.project_normalizer(project_from_path(root, transcript))
+        context = PromptContext()
+        try:
+            handle = transcript.open(errors="replace")
+        except OSError:
+            return
+        with handle:
+            for line in handle:
+                if not line.strip():
+                    continue
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError:
+                    self.malformed_json_records += 1
+                    continue
+                if not isinstance(record, dict):
+                    continue
+                timestamp = parse_timestamp(record.get("timestamp") or record.get("created_at") or record.get("createdAt") or record.get("time"))
+                if not self._in_window(timestamp):
+                    continue
+                if timestamp is not None:
+                    self.timestamps.append(timestamp)
+                context = update_context(context, record, timestamp)
+                usage = extract_usage(record)
+                if not usage:
+                    continue
+                key = dedupe_key(record, usage)
+                if key in self.seen_api_keys:
+                    self.duplicate_records += 1
+                    continue
+                self.seen_api_keys.add(key)
+                model = extract_model(record)
+                self._add_usage(project, model, usage, runtime_classification(record), context, timestamp)
+
+    def _in_window(self, timestamp: int | None) -> bool:
+        selected = self.query.window
+        if selected.kind == "all":
+            return True
+        if timestamp is None:
+            self.skipped_unparseable_timestamps += 1
+            return False
+        if selected.window_start is not None and timestamp < selected.window_start:
+            return False
+        if selected.window_end is not None and timestamp > selected.window_end:
+            return False
+        return True
+
+    def _add_usage(
+        self,
+        project: str,
+        model: str,
+        usage: Usage,
+        runtime_class: str,
+        context: PromptContext,
+        timestamp: int | None,
+    ) -> None:
+        self.totals.add(usage, model)
+        self.by_project[project].add(usage, model)
+        model_key = model or "unknown"
+        self.by_model[model_key].add(usage, model_key)
+        if context.subagent_type:
+            self.by_subagent[context.subagent_type].add(usage, model)
+        if context.skill:
+            self.by_skill[context.skill].add(usage, model)
+        if context.slash_command:
+            self.by_slash_command[context.slash_command].add(usage, model)
+        self.runtime_by_class[runtime_class].add(usage, model)
+        total = usage_total(usage)
+        if context.text:
+            preview, prompt_hash = redact_prompt(context.text, self.query.redaction)
+            self.expensive_prompts.append(
+                {
+                    "project": project,
+                    "prompt_preview": preview,
+                    "prompt_hash": prompt_hash,
+                    "timestamp": timestamp,
+                    "total_tokens": total,
+                    "api_calls": 1,
+                    "subagent_type": context.subagent_type,
+                    "slash_command": context.slash_command,
+                    "skill": context.skill,
+                    "redaction": self.query.redaction,
+                }
+            )
+        if usage["cache_creation_input_tokens"] > 0 and usage["cache_creation_input_tokens"] >= usage["cache_read_input_tokens"]:
+            preview, prompt_hash = redact_prompt(context.text, self.query.redaction)
+            self.cache_breaks.append(
+                {
+                    "project": project,
+                    "timestamp": timestamp,
+                    "reason": "cache_creation_spike_after_prompt_change",
+                    "tokens": usage["cache_creation_input_tokens"],
+                    "prompt_hash": prompt_hash,
+                    "prompt_preview": preview,
+                }
+            )
+
+    def _totals(self) -> dict[str, Any]:
+        cache_total = self.totals.cache_read_input_tokens + self.totals.cache_creation_input_tokens
+        return {
+            "input_tokens": self.totals.input_tokens,
+            "output_tokens": self.totals.output_tokens,
+            "cache_read_input_tokens": self.totals.cache_read_input_tokens,
+            "cache_creation_input_tokens": self.totals.cache_creation_input_tokens,
+            "total_tokens": self.totals.total_tokens,
+            "api_calls": self.totals.api_calls,
+            "deduped_api_calls": self.duplicate_records,
+            "cache_hit_pct": round(self.totals.cache_read_input_tokens / cache_total * 100, 1) if cache_total else 0.0,
+            "active_seconds": active_seconds(self.timestamps, self.active_gap_seconds),
+            "wall_seconds": wall_seconds(self.timestamps),
+        }
+
+    def _rows(self, aggregates: dict[str, Aggregate]) -> list[dict[str, Any]]:
+        total = self.totals.total_tokens
+        return [aggregate_row(name, aggregate, total) for name, aggregate in sorted(aggregates.items(), key=lambda item: -item[1].total_tokens)]
+
+    def _runtime_attribution(self) -> dict[str, Any]:
+        human = self.runtime_by_class.get("human", Aggregate()).total_tokens
+        runtime = self.runtime_by_class.get("runtime", Aggregate()).total_tokens
+        unknown = self.runtime_by_class.get("unknown", Aggregate()).total_tokens
+        return {
+            "human_tokens": human,
+            "runtime_tokens": runtime,
+            "unknown_tokens": unknown,
+            "by_class": self._rows(self.runtime_by_class),
+        }
+
+    def _reconciliation(self) -> dict[str, Any]:
+        session_total = self.totals.total_tokens
+        delta = None if self.quota_scanner_total_tokens is None else session_total - self.quota_scanner_total_tokens
+        delta_pct = None
+        if delta is not None and self.quota_scanner_total_tokens:
+            delta_pct = round(delta / self.quota_scanner_total_tokens * 100, 1)
+        notes = []
+        if self.quota_scanner_total_tokens is None:
+            notes.append("quota scanner total unavailable")
+        if self.duplicate_records:
+            notes.append(f"deduped {self.duplicate_records} duplicate transcript records")
+        return {
+            "quota_scanner_total_tokens": self.quota_scanner_total_tokens,
+            "session_total_tokens": session_total,
+            "delta_tokens": delta,
+            "delta_pct": delta_pct,
+            "notes": notes,
+        }
+
+    def _finalize_warnings(self) -> None:
+        if self.skipped_oversized_files:
+            self.warnings.append(f"skipped {self.skipped_oversized_files} oversized transcript files")
+        if self.skipped_unparseable_timestamps:
+            self.warnings.append(f"skipped {self.skipped_unparseable_timestamps} records without parseable timestamps")
+        if self.malformed_json_records:
+            self.warnings.append(f"skipped {self.malformed_json_records} malformed json records")
+
+
+def extract_usage(record: dict[str, Any]) -> Usage | None:
+    raw = nested_dict(record, "message", "usage") or record.get("usage")
+    if not isinstance(raw, dict):
+        return None
+    usage = {
+        "input_tokens": coerce_int(raw.get("input_tokens")),
+        "output_tokens": coerce_int(raw.get("output_tokens")),
+        "cache_read_input_tokens": coerce_int(raw.get("cache_read_input_tokens")),
+        "cache_creation_input_tokens": coerce_int(raw.get("cache_creation_input_tokens")),
+    }
+    return usage if usage_total(usage) > 0 else None
+
+
+def extract_model(record: dict[str, Any]) -> str:
+    return str(nested_value(record, "message", "model") or record.get("model") or "unknown").split("/")[-1]
+
+
+def dedupe_key(record: dict[str, Any], usage: Usage) -> str:
+    request_id = record.get("requestId") or record.get("request_id") or nested_value(record, "message", "requestId")
+    if request_id:
+        return f"request:{request_id}"
+    message_id = nested_value(record, "message", "id") or record.get("message_id")
+    if message_id:
+        return f"message:{message_id}"
+    usage_tuple = tuple(usage[key] for key in sorted(usage))
+    uuid = record.get("uuid")
+    if uuid:
+        return f"uuid:{uuid}:{usage_tuple}"
+    return f"synthetic:{record.get('timestamp')}:{extract_model(record)}:{usage_tuple}"
+
+
+def update_context(context: PromptContext, record: dict[str, Any], timestamp: int | None) -> PromptContext:
+    prompt = user_prompt_text(record)
+    tool_context = tool_use_context(record)
+    slash_command = slash_command_from_prompt(prompt) if prompt else context.slash_command
+    return PromptContext(
+        text=prompt or context.text,
+        slash_command=slash_command,
+        skill=tool_context.get("skill") or context.skill,
+        subagent_type=tool_context.get("subagent_type") or context.subagent_type,
+        timestamp=timestamp or context.timestamp,
+    )
+
+
+def user_prompt_text(record: dict[str, Any]) -> str:
+    message = record.get("message") if isinstance(record.get("message"), dict) else {}
+    role = message.get("role") or record.get("role") or record.get("type")
+    if role != "user":
+        return ""
+    return text_from_content(message.get("content") if "content" in message else record.get("content"))
+
+
+def text_from_content(content: Any) -> str:
+    if isinstance(content, str):
+        return content.strip()
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, str):
+                parts.append(item)
+            elif isinstance(item, dict) and isinstance(item.get("text"), str):
+                parts.append(item["text"])
+        return "\n".join(part.strip() for part in parts if part.strip()).strip()
+    return ""
+
+
+def tool_use_context(record: dict[str, Any]) -> dict[str, str]:
+    result: dict[str, str] = {}
+    message = record.get("message") if isinstance(record.get("message"), dict) else {}
+    blocks = message.get("content") if "content" in message else record.get("content")
+    if not isinstance(blocks, list):
+        return result
+    for block in blocks:
+        if not isinstance(block, dict) or block.get("type") != "tool_use":
+            continue
+        name = str(block.get("name") or "")
+        raw_input = block.get("input") if isinstance(block.get("input"), dict) else {}
+        if name.lower() == "skill":
+            skill = raw_input.get("skill") or raw_input.get("name") or raw_input.get("command")
+            if skill:
+                result["skill"] = str(skill)
+        if name.lower() in {"agent", "task"}:
+            subagent = raw_input.get("subagent_type") or raw_input.get("agent_type") or raw_input.get("type") or raw_input.get("description")
+            if subagent:
+                result["subagent_type"] = str(subagent)
+    return result
+
+
+def slash_command_from_prompt(prompt: str) -> str | None:
+    match = re.match(r"^\s*/([A-Za-z0-9_.-]+)", prompt)
+    return f"/{match.group(1)}" if match else None
+
+
+def runtime_classification(record: dict[str, Any]) -> str:
+    value = record.get("usage_class") or record.get("runtime_class") or record.get("LLM_USAGE_CLASS")
+    if value in {"human", "runtime"}:
+        return str(value)
+    env = record.get("env")
+    if isinstance(env, dict) and env.get("LLM_USAGE_CLASS") == "runtime":
+        return "runtime"
+    return "unknown"
+
+
+def aggregate_row(name: str, aggregate: Aggregate, total_tokens: int) -> dict[str, Any]:
+    return {
+        "name": name,
+        "display_name": name,
+        "total_tokens": aggregate.total_tokens,
+        "api_calls": aggregate.api_calls,
+        "share_pct": round(aggregate.total_tokens / total_tokens * 100, 1) if total_tokens else 0.0,
+        "input_tokens": aggregate.input_tokens,
+        "output_tokens": aggregate.output_tokens,
+        "cache_read_input_tokens": aggregate.cache_read_input_tokens,
+        "cache_creation_input_tokens": aggregate.cache_creation_input_tokens,
+        "models": dict(sorted(aggregate.models.items(), key=lambda item: -item[1])),
+    }
+
+
+def redact_prompt(prompt: str, redaction: str) -> tuple[str, str]:
+    digest = "sha256:" + hashlib.sha256(prompt.encode("utf-8", errors="replace")).hexdigest()
+    if redaction == "none":
+        return prompt, digest
+    if redaction == "summary":
+        return " ".join(prompt.split()[:12]), digest
+    compact = " ".join(prompt.split())
+    return (compact[:157] + "...") if len(compact) > 160 else compact, digest
+
+
+def active_seconds(timestamps: list[int], gap_seconds: int) -> int:
+    ordered = sorted(set(timestamps))
+    if len(ordered) < 2:
+        return 0
+    total = 0
+    previous = ordered[0]
+    for current in ordered[1:]:
+        gap = current - previous
+        if 0 < gap <= gap_seconds:
+            total += gap
+        previous = current
+    return total
+
+
+def wall_seconds(timestamps: list[int]) -> int:
+    return max(timestamps) - min(timestamps) if len(timestamps) >= 2 else 0
+
+
+def parse_timestamp(value: Any) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        number = float(value)
+        return int(number / 1000) if number > 10_000_000_000 else int(number)
+    if not isinstance(value, str):
+        return None
+    try:
+        return int(datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp())
+    except ValueError:
+        return None
+
+
+def usage_total(usage: Usage) -> int:
+    return sum(int(value) for value in usage.values())
+
+
+def coerce_int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def nested_value(data: dict[str, Any], *keys: str) -> Any:
+    current: Any = data
+    for key in keys:
+        if not isinstance(current, dict):
+            return None
+        current = current.get(key)
+    return current
+
+
+def nested_dict(data: dict[str, Any], *keys: str) -> dict[str, Any] | None:
+    value = nested_value(data, *keys)
+    return value if isinstance(value, dict) else None
+
+
+def project_from_path(root: Path, transcript: Path) -> str:
+    try:
+        relative = transcript.relative_to(root)
+    except ValueError:
+        return transcript.parent.name or "unknown"
+    if len(relative.parts) >= 2 and relative.parts[0] == "subagents":
+        return transcript.parent.parent.name or "subagents"
+    return relative.parts[0] if relative.parts else transcript.parent.name or "unknown"

--- a/quota_core/session/report.py
+++ b/quota_core/session/report.py
@@ -1,0 +1,341 @@
+"""Public session analytics API envelope and query semantics."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import time
+from typing import Any, Literal
+
+CacheState = Literal["live", "cached", "stale"]
+RedactionMode = Literal["summary", "preview", "none"]
+WindowKind = Literal["quota", "rolling", "all"]
+
+DEFAULT_SINCE = "24h"
+DEFAULT_REDACTION: RedactionMode = "preview"
+
+QUOTA_WINDOWS = {
+    "5h": ("five_hour", 5 * 3600),
+    "7d": ("seven_day", 7 * 24 * 3600),
+}
+ROLLING_SINCE_SECONDS = {
+    "24h": 24 * 3600,
+    "7d": 7 * 24 * 3600,
+    "30d": 30 * 24 * 3600,
+}
+
+
+@dataclass(frozen=True)
+class SessionReportWindow:
+    """Window selected for a Claude session analytics report."""
+
+    kind: WindowKind
+    name: str
+    window_start: int | None
+    window_end: int | None
+    window_source: str
+
+
+@dataclass(frozen=True)
+class SessionReportQuery:
+    """Normalized query options for the session report endpoint."""
+
+    window: SessionReportWindow
+    redaction: RedactionMode = DEFAULT_REDACTION
+    requested_window: str | None = None
+    requested_since: str | None = DEFAULT_SINCE
+
+
+def normalize_session_report_query(
+    *,
+    window: str | None = None,
+    since: str | None = None,
+    redaction: str | None = None,
+    now: int | None = None,
+    quota_windows: dict[str, Any] | None = None,
+) -> SessionReportQuery:
+    """Normalize endpoint query parameters into one selected report window.
+
+    `window` wins over `since` because quota-card diagnostics should use the
+    current quota window even if callers pass a stale rolling selector too.
+    """
+
+    selected_redaction = _normalize_redaction(redaction)
+    selected_now = int(time.time()) if now is None else int(now)
+    selected_window = _select_window(
+        window=window,
+        since=since or DEFAULT_SINCE,
+        now=selected_now,
+        quota_windows=quota_windows or {},
+    )
+    return SessionReportQuery(
+        window=selected_window,
+        redaction=selected_redaction,
+        requested_window=window,
+        requested_since=since or DEFAULT_SINCE,
+    )
+
+
+def build_empty_session_report(
+    *,
+    window: str | None = None,
+    since: str | None = None,
+    redaction: str | None = None,
+    generated_at: int | None = None,
+    cache_state: CacheState = "live",
+    cache_age_seconds: int = 0,
+    warnings: list[str] | tuple[str, ...] = (),
+    errors: list[str] | tuple[str, ...] = (),
+    quota_windows: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a schema-shaped empty Claude session analytics response."""
+
+    now = int(time.time()) if generated_at is None else int(generated_at)
+    query = normalize_session_report_query(
+        window=window,
+        since=since,
+        redaction=redaction,
+        now=now,
+        quota_windows=quota_windows,
+    )
+    return build_session_report(
+        query=query,
+        generated_at=now,
+        cache_state=cache_state,
+        cache_age_seconds=cache_age_seconds,
+        warnings=warnings,
+        errors=errors,
+    )
+
+
+def build_session_report(
+    *,
+    query: SessionReportQuery,
+    generated_at: int,
+    cache_state: CacheState = "live",
+    cache_age_seconds: int = 0,
+    totals: dict[str, Any] | None = None,
+    by_project: list[dict[str, Any]] | None = None,
+    by_model: list[dict[str, Any]] | None = None,
+    by_subagent: list[dict[str, Any]] | None = None,
+    by_skill: list[dict[str, Any]] | None = None,
+    by_slash_command: list[dict[str, Any]] | None = None,
+    expensive_prompts: list[dict[str, Any]] | None = None,
+    cache_breaks: list[dict[str, Any]] | None = None,
+    runtime_attribution: dict[str, Any] | None = None,
+    reconciliation: dict[str, Any] | None = None,
+    warnings: list[str] | tuple[str, ...] = (),
+    errors: list[str] | tuple[str, ...] = (),
+) -> dict[str, Any]:
+    """Build a Claude session analytics response envelope."""
+
+    return {
+        "source": "claude",
+        "generated_at": int(generated_at),
+        "cache_state": cache_state,
+        "cache_age_seconds": int(cache_age_seconds),
+        "redaction": query.redaction,
+        "window": _window_to_dict(query.window),
+        "totals": _totals(totals),
+        "by_project": list(by_project or []),
+        "by_model": list(by_model or []),
+        "by_subagent": list(by_subagent or []),
+        "by_skill": list(by_skill or []),
+        "by_slash_command": list(by_slash_command or []),
+        "expensive_prompts": list(expensive_prompts or []),
+        "cache_breaks": list(cache_breaks or []),
+        "runtime_attribution": runtime_attribution or _runtime_attribution(),
+        "reconciliation": reconciliation or _reconciliation(),
+        "warnings": [str(warning) for warning in warnings],
+        "errors": [str(error) for error in errors],
+    }
+
+
+def validate_session_report_dict(report: dict[str, Any]) -> tuple[str, ...]:
+    """Return validation errors for the public session analytics envelope."""
+
+    errors: list[str] = []
+    required = (
+        "source",
+        "generated_at",
+        "cache_state",
+        "cache_age_seconds",
+        "window",
+        "totals",
+        "by_project",
+        "by_model",
+        "by_subagent",
+        "by_skill",
+        "by_slash_command",
+        "expensive_prompts",
+        "cache_breaks",
+        "runtime_attribution",
+        "reconciliation",
+        "warnings",
+        "errors",
+    )
+    for key in required:
+        if key not in report:
+            errors.append(f"{key} is required")
+    if report.get("source") != "claude":
+        errors.append("source must be claude")
+    if not isinstance(report.get("generated_at"), int):
+        errors.append("generated_at must be an integer unix timestamp")
+    if report.get("cache_state") not in {"live", "cached", "stale"}:
+        errors.append("cache_state must be live, cached, or stale")
+    if not isinstance(report.get("cache_age_seconds"), int):
+        errors.append("cache_age_seconds must be an integer")
+    _validate_window(report.get("window"), errors)
+    _validate_totals(report.get("totals"), errors)
+    for key in (
+        "by_project",
+        "by_model",
+        "by_subagent",
+        "by_skill",
+        "by_slash_command",
+        "expensive_prompts",
+        "cache_breaks",
+    ):
+        if not isinstance(report.get(key), list):
+            errors.append(f"{key} must be a list")
+    if not isinstance(report.get("runtime_attribution"), dict):
+        errors.append("runtime_attribution must be an object")
+    if not isinstance(report.get("reconciliation"), dict):
+        errors.append("reconciliation must be an object")
+    if not isinstance(report.get("warnings"), list):
+        errors.append("warnings must be a list")
+    if not isinstance(report.get("errors"), list):
+        errors.append("errors must be a list")
+    return tuple(errors)
+
+
+def _select_window(*, window: str | None, since: str, now: int, quota_windows: dict[str, Any]) -> SessionReportWindow:
+    if window in QUOTA_WINDOWS:
+        name, default_seconds = QUOTA_WINDOWS[window]
+        metadata = quota_windows.get(name, {})
+        resets_at = _optional_int(metadata.get("resets_at")) if isinstance(metadata, dict) else None
+        window_seconds = _optional_int(metadata.get("window_seconds")) if isinstance(metadata, dict) else None
+        if window_seconds is None:
+            window_seconds = default_seconds
+        window_start = resets_at - window_seconds if resets_at is not None else None
+        window_end = min(now, resets_at) if resets_at is not None else now
+        return SessionReportWindow(
+            kind="quota",
+            name=name,
+            window_start=window_start,
+            window_end=window_end,
+            window_source="quota_resets_at",
+        )
+
+    if since == "all":
+        return SessionReportWindow(
+            kind="all",
+            name="all",
+            window_start=None,
+            window_end=now,
+            window_source="all_transcripts",
+        )
+
+    seconds = ROLLING_SINCE_SECONDS.get(since, ROLLING_SINCE_SECONDS[DEFAULT_SINCE])
+    name = since if since in ROLLING_SINCE_SECONDS else DEFAULT_SINCE
+    return SessionReportWindow(
+        kind="rolling",
+        name=name,
+        window_start=now - seconds,
+        window_end=now,
+        window_source="rolling_since",
+    )
+
+
+def _normalize_redaction(redaction: str | None) -> RedactionMode:
+    if redaction in {"summary", "preview", "none"}:
+        return redaction  # type: ignore[return-value]
+    return DEFAULT_REDACTION
+
+
+def _window_to_dict(window: SessionReportWindow) -> dict[str, Any]:
+    return {
+        "kind": window.kind,
+        "name": window.name,
+        "window_start": window.window_start,
+        "window_end": window.window_end,
+        "window_source": window.window_source,
+    }
+
+
+def _totals(totals: dict[str, Any] | None = None) -> dict[str, Any]:
+    data = {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cache_read_input_tokens": 0,
+        "cache_creation_input_tokens": 0,
+        "total_tokens": 0,
+        "api_calls": 0,
+        "deduped_api_calls": 0,
+        "cache_hit_pct": 0.0,
+        "active_seconds": 0,
+        "wall_seconds": 0,
+    }
+    if totals:
+        data.update(totals)
+    return data
+
+
+def _runtime_attribution() -> dict[str, Any]:
+    return {
+        "human_tokens": 0,
+        "runtime_tokens": 0,
+        "unknown_tokens": 0,
+        "by_class": [],
+    }
+
+
+def _reconciliation() -> dict[str, Any]:
+    return {
+        "quota_scanner_total_tokens": None,
+        "session_total_tokens": 0,
+        "delta_tokens": None,
+        "delta_pct": None,
+        "notes": [],
+    }
+
+
+def _optional_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _validate_window(window: Any, errors: list[str]) -> None:
+    if not isinstance(window, dict):
+        errors.append("window must be an object")
+        return
+    for key in ("kind", "name", "window_source"):
+        if not isinstance(window.get(key), str) or not window.get(key):
+            errors.append(f"window.{key} must be a non-empty string")
+    for key in ("window_start", "window_end"):
+        if window.get(key) is not None and not isinstance(window.get(key), int):
+            errors.append(f"window.{key} must be an integer or null")
+
+
+def _validate_totals(totals: Any, errors: list[str]) -> None:
+    if not isinstance(totals, dict):
+        errors.append("totals must be an object")
+        return
+    for key in (
+        "input_tokens",
+        "output_tokens",
+        "cache_read_input_tokens",
+        "cache_creation_input_tokens",
+        "total_tokens",
+        "api_calls",
+        "deduped_api_calls",
+        "active_seconds",
+        "wall_seconds",
+    ):
+        if not isinstance(totals.get(key), int):
+            errors.append(f"totals.{key} must be an integer")
+    if not isinstance(totals.get("cache_hit_pct"), (int, float)):
+        errors.append("totals.cache_hit_pct must be numeric")

--- a/tests/test_quota_core.py
+++ b/tests/test_quota_core.py
@@ -13,6 +13,7 @@ from quota_core.adapters.projects import normalize_project_name
 from quota_core.adapters.gemini import normalize_gemini_usage
 from quota_core.config import config_from_mapping, load_config, validate_config, write_default_config
 from quota_core.runtime import runtime_env
+from quota_core.session import build_empty_session_report, normalize_session_report_query, validate_session_report_dict
 from quota_core.snapshot import AggregateBreakdown, NormalizedSnapshot, RuntimeBreakdown, SnapshotWindow, snapshot_to_dict, validate_snapshot_dict
 from quota_core.cli import scan_config, write_dashboard, write_demo, write_scan
 from quota_core.dashboard.renderer import render_page
@@ -640,6 +641,54 @@ class SnapshotTests(unittest.TestCase):
         snapshot = snapshot_to_dict(scan_config(config)[0])
         self.assertEqual(snapshot["warnings"], ["gemini tmp_dir does not exist"])
         self.assertNotIn("/tmp/quota-core-private-gemini-tmp", json.dumps(snapshot))
+
+
+class SessionReportContractTests(unittest.TestCase):
+    def test_session_report_window_query_wins_over_since(self):
+        query = normalize_session_report_query(
+            window="5h",
+            since="24h",
+            redaction="summary",
+            now=1770000000,
+            quota_windows={"five_hour": {"resets_at": 1770003600, "window_seconds": 5 * 3600}},
+        )
+        self.assertEqual(query.redaction, "summary")
+        self.assertEqual(query.window.kind, "quota")
+        self.assertEqual(query.window.name, "five_hour")
+        self.assertEqual(query.window.window_start, 1769985600)
+        self.assertEqual(query.window.window_end, 1770000000)
+        self.assertEqual(query.window.window_source, "quota_resets_at")
+
+    def test_session_report_defaults_to_preview_redaction(self):
+        query = normalize_session_report_query(since="24h", now=1770000000)
+        self.assertEqual(query.redaction, "preview")
+        self.assertEqual(query.window.kind, "rolling")
+        self.assertEqual(query.window.name, "24h")
+        self.assertEqual(query.window.window_start, 1769913600)
+        self.assertEqual(query.window.window_end, 1770000000)
+        self.assertEqual(query.window.window_source, "rolling_since")
+
+    def test_empty_session_report_has_required_schema_keys(self):
+        report = build_empty_session_report(generated_at=1770000000)
+        self.assertEqual(validate_session_report_dict(report), ())
+        self.assertEqual(report["source"], "claude")
+        self.assertEqual(report["cache_state"], "live")
+        self.assertEqual(report["redaction"], "preview")
+        self.assertEqual(report["totals"]["total_tokens"], 0)
+        self.assertEqual(report["runtime_attribution"]["by_class"], [])
+        self.assertEqual(report["reconciliation"]["session_total_tokens"], 0)
+        for key in (
+            "by_project",
+            "by_model",
+            "by_subagent",
+            "by_skill",
+            "by_slash_command",
+            "expensive_prompts",
+            "cache_breaks",
+            "warnings",
+            "errors",
+        ):
+            self.assertEqual(report[key], [])
 
 
 class PublicSplitGuardTests(unittest.TestCase):

--- a/tests/test_quota_core.py
+++ b/tests/test_quota_core.py
@@ -9,11 +9,12 @@ import unittest
 from pathlib import Path
 
 from quota_core.adapters.claude import normalize_claude_quota
+from quota_core.adapters.codex import normalize_codex_quota
 from quota_core.adapters.projects import normalize_project_name
 from quota_core.adapters.gemini import normalize_gemini_usage
 from quota_core.config import config_from_mapping, load_config, validate_config, write_default_config
 from quota_core.runtime import runtime_env
-from quota_core.session import build_empty_session_report, normalize_session_report_query, validate_session_report_dict
+from quota_core.session import analyze_claude_sessions, build_empty_session_report, normalize_session_report_query, validate_session_report_dict
 from quota_core.snapshot import AggregateBreakdown, NormalizedSnapshot, RuntimeBreakdown, SnapshotWindow, snapshot_to_dict, validate_snapshot_dict
 from quota_core.cli import scan_config, write_dashboard, write_demo, write_scan
 from quota_core.dashboard.renderer import render_page
@@ -111,6 +112,81 @@ class SnapshotTests(unittest.TestCase):
         snapshot = snapshot_to_dict(normalize_claude_quota(payload))
         self.assertEqual(validate_snapshot_dict(snapshot), ())
         self.assertEqual(snapshot["windows"]["five_hour"]["runtime"]["total_tokens"], 200)
+
+    def test_claude_usage_payload_accepts_explicit_cache_state(self):
+        payload = {
+            "fetched_at": 1778166600,
+            "cache_state": "cached",
+            "current_session": {
+                "utilization": 0.06,
+                "resets_at": 1778180340,
+                "window_seconds": 5 * 3600,
+                "tokens_used": 0,
+                "by_project": {},
+            },
+            "current_week": {
+                "utilization": 0.14,
+                "resets_at": 1778731200,
+                "window_seconds": 7 * 24 * 3600,
+                "tokens_used": 0,
+                "by_project": {},
+            },
+            "current_week_sonnet": {
+                "utilization": 0.09,
+                "resets_at": 1778731200,
+                "window_seconds": 7 * 24 * 3600,
+                "tokens_used": 0,
+                "by_project": {},
+            },
+        }
+        snapshot = snapshot_to_dict(normalize_claude_quota(payload))
+        self.assertEqual(validate_snapshot_dict(snapshot), ())
+        self.assertEqual(snapshot["windows"]["current_session"]["cache_state"], "cached")
+        self.assertEqual(snapshot["windows"]["current_week"]["utilization"], 0.14)
+        self.assertEqual(snapshot["windows"]["current_week_sonnet"]["utilization"], 0.09)
+
+    def test_codex_stale_payload_normalizes_cache_state(self):
+        payload = {
+            "fetched_at": 1770000000,
+            "stale": True,
+            "five_hour": {
+                "utilization": 0.01,
+                "resets_at": 1770003600,
+                "tokens_used": 0,
+            },
+            "seven_day": {
+                "utilization": 0.0,
+                "resets_at": 1770604800,
+                "tokens_used": 72090696,
+                "by_project": {
+                    "alpha-engine": {
+                        "tokens": 71461699,
+                        "models": {"gpt-5.4-mini": 71461699},
+                    }
+                },
+            },
+        }
+        snapshot = snapshot_to_dict(normalize_codex_quota(payload))
+        self.assertEqual(validate_snapshot_dict(snapshot), ())
+        self.assertEqual(snapshot["windows"]["five_hour"]["cache_state"], "stale")
+        self.assertTrue(snapshot["windows"]["seven_day"]["stale"])
+        self.assertEqual(snapshot["windows"]["seven_day"]["total_tokens"], 72090696)
+
+    def test_codex_payload_accepts_explicit_cache_state(self):
+        payload = {
+            "fetched_at": 1770000000,
+            "cache_state": "cached",
+            "five_hour": {
+                "utilization": 0.16,
+                "resets_at": 1770003600,
+                "tokens_used": 10,
+            },
+        }
+
+        snapshot = snapshot_to_dict(normalize_codex_quota(payload))
+
+        self.assertEqual(snapshot["windows"]["five_hour"]["cache_state"], "cached")
+        self.assertFalse(snapshot["windows"]["five_hour"]["stale"])
 
     def test_agent_crew_worktree_projects_merge_with_parent_project(self):
         payload = {
@@ -689,6 +765,83 @@ class SessionReportContractTests(unittest.TestCase):
             "errors",
         ):
             self.assertEqual(report[key], [])
+
+    def test_claude_session_parser_dedupes_and_attributes(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            project_dir = Path(temp_dir) / "demo-project"
+            project_dir.mkdir()
+            rows = [
+                {
+                    "timestamp": "2026-05-07T00:00:00Z",
+                    "message": {"role": "user", "content": "/investigate why cache exploded"},
+                },
+                {
+                    "timestamp": "2026-05-07T00:00:01Z",
+                    "message": {
+                        "role": "assistant",
+                        "content": [
+                            {"type": "tool_use", "name": "Skill", "input": {"name": "systematic-debugging"}},
+                            {"type": "tool_use", "name": "Task", "input": {"subagent_type": "Explore"}},
+                        ],
+                    },
+                },
+                {
+                    "timestamp": "2026-05-07T00:00:02Z",
+                    "requestId": "req-1",
+                    "message": {
+                        "id": "msg-1",
+                        "model": "claude-sonnet-4-6",
+                        "usage": {
+                            "input_tokens": 10,
+                            "output_tokens": 20,
+                            "cache_read_input_tokens": 30,
+                            "cache_creation_input_tokens": 40,
+                        },
+                    },
+                },
+                {
+                    "timestamp": "2026-05-07T00:00:02Z",
+                    "requestId": "req-1",
+                    "message": {
+                        "id": "msg-1-split-block",
+                        "model": "claude-sonnet-4-6",
+                        "usage": {
+                            "input_tokens": 10,
+                            "output_tokens": 20,
+                            "cache_read_input_tokens": 30,
+                            "cache_creation_input_tokens": 40,
+                        },
+                    },
+                },
+            ]
+            (project_dir / "session.jsonl").write_text("\n".join(json.dumps(row) for row in rows) + "\n")
+
+            report = analyze_claude_sessions([temp_dir], since="24h", redaction="preview", now=1778169600, quota_scanner_total_tokens=120)
+
+        self.assertEqual(validate_session_report_dict(report), ())
+        self.assertEqual(report["totals"]["total_tokens"], 100)
+        self.assertEqual(report["totals"]["api_calls"], 1)
+        self.assertEqual(report["totals"]["deduped_api_calls"], 1)
+        self.assertEqual(report["totals"]["cache_hit_pct"], 42.9)
+        self.assertEqual(report["by_project"][0]["name"], "demo-project")
+        self.assertEqual(report["by_model"][0]["name"], "claude-sonnet-4-6")
+        self.assertEqual(report["by_subagent"][0]["name"], "Explore")
+        self.assertEqual(report["by_skill"][0]["name"], "systematic-debugging")
+        self.assertEqual(report["by_slash_command"][0]["name"], "/investigate")
+        self.assertIn("cache_creation_spike", report["cache_breaks"][0]["reason"])
+        self.assertIn("/investigate why cache", report["expensive_prompts"][0]["prompt_preview"])
+        self.assertEqual(report["reconciliation"]["quota_scanner_total_tokens"], 120)
+
+    def test_dashboard_renders_claude_session_report(self):
+        report = build_empty_session_report(generated_at=1770000000)
+        report["totals"].update({"total_tokens": 300, "input_tokens": 100, "output_tokens": 80, "cache_read_input_tokens": 90, "cache_creation_input_tokens": 30, "cache_hit_pct": 75.0})
+        report["by_project"] = [{"name": "demo-project", "display_name": "demo-project", "total_tokens": 300, "share_pct": 100.0}]
+        report["expensive_prompts"] = [{"prompt_preview": "expensive prompt", "total_tokens": 300}]
+        snapshot = NormalizedSnapshot(source="claude", sampled_at=1770000000, history={"claude_session_report": report})
+        page = render_page([snapshot])
+        self.assertIn("Claude Sessions", page)
+        self.assertIn("demo-project", page)
+        self.assertIn("expensive prompt", page)
 
 
 class PublicSplitGuardTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

Implements issue #28 as a normal PR, stacked on #46 because the original implementation was accidentally pushed directly to `main`.

After #46 lands, retarget this PR to `main` before merge.

## Changes

- Adds public `quota_core.session` report envelope/query helpers.
- Adds schema-shaped empty Claude session report builder.
- Implements query precedence where `window` beats `since`.
- Defaults redaction to `preview`.
- Adds skeleton `/api/claude_session_report` endpoint.
- Adds contract tests for #28 verification plan.

## Verification

- `/home/truhojun/.pyenv/versions/3.12.9/bin/python -m unittest tests.test_quota_core -v`

Refs #28
Depends on #46