### PR TITLE
Improve Claude session diagnostics

### DIFF
--- a/quota_core/dashboard/components.py
+++ b/quota_core/dashboard/components.py
@@ -245,7 +245,10 @@ def expensive_prompt_rows(rows: object) -> str:
             continue
         preview = str(row.get("prompt_preview") or row.get("prompt_hash") or "redacted")
         tokens = compact_number(int(row.get("total_tokens") or 0))
-        items.append(f'<li><span>{html.escape(preview)}</span><strong>{html.escape(tokens)}</strong></li>')
+        project = str(row.get("project") or "unknown")
+        calls = int(row.get("api_calls") or 0)
+        right = f"{tokens}{f' · {calls} calls' if calls else ''}"
+        items.append(f'<li><span>{html.escape(project)} · {html.escape(preview)}</span><strong>{html.escape(right)}</strong></li>')
     return f'<article class="session-card session-card-wide"><h3>Expensive Prompts</h3><ol class="runtime-project-list">{"".join(items)}</ol></article>' if items else ""
 
 
@@ -256,9 +259,12 @@ def cache_break_rows(rows: object) -> str:
     for row in rows[:5]:
         if not isinstance(row, dict):
             continue
-        reason = str(row.get("reason") or "cache break")
+        preview = str(row.get("prompt_preview") or row.get("reason") or row.get("prompt_hash") or "cache break")
+        project = str(row.get("project") or "unknown")
         tokens = compact_number(int(row.get("tokens") or 0))
-        items.append(f'<li><span>{html.escape(reason)}</span><strong>{html.escape(tokens)}</strong></li>')
+        calls = int(row.get("api_calls") or 0)
+        right = f"{tokens}{f' · {calls} calls' if calls else ''}"
+        items.append(f'<li><span>{html.escape(project)} · {html.escape(preview)}</span><strong>{html.escape(right)}</strong></li>')
     return f'<article class="session-card session-card-wide"><h3>Cache Breaks</h3><ol class="runtime-project-list">{"".join(items)}</ol></article>' if items else ""
 
 

--- a/quota_core/session/claude.py
+++ b/quota_core/session/claude.py
@@ -115,8 +115,8 @@ class ClaudeSessionScanner:
         self.by_skill: dict[str, Aggregate] = defaultdict(Aggregate)
         self.by_slash_command: dict[str, Aggregate] = defaultdict(Aggregate)
         self.runtime_by_class: dict[str, Aggregate] = defaultdict(Aggregate)
-        self.expensive_prompts: list[dict[str, Any]] = []
-        self.cache_breaks: list[dict[str, Any]] = []
+        self.expensive_prompts: dict[str, dict[str, Any]] = {}
+        self.cache_breaks: dict[str, dict[str, Any]] = {}
         self.seen_api_keys: set[str] = set()
         self.duplicate_records = 0
         self.skipped_oversized_files = 0
@@ -138,8 +138,8 @@ class ClaudeSessionScanner:
             by_subagent=self._rows(self.by_subagent),
             by_skill=self._rows(self.by_skill),
             by_slash_command=self._rows(self.by_slash_command),
-            expensive_prompts=sorted(self.expensive_prompts, key=lambda row: -int(row["total_tokens"]))[:20],
-            cache_breaks=sorted(self.cache_breaks, key=lambda row: -int(row["tokens"]))[:20],
+            expensive_prompts=sorted(self.expensive_prompts.values(), key=lambda row: -int(row["total_tokens"]))[:20],
+            cache_breaks=sorted(self.cache_breaks.values(), key=lambda row: -int(row["tokens"]))[:20],
             runtime_attribution=self._runtime_attribution(),
             reconciliation=self._reconciliation(),
             warnings=self.warnings,
@@ -230,32 +230,39 @@ class ClaudeSessionScanner:
         total = usage_total(usage)
         if context.text:
             preview, prompt_hash = redact_prompt(context.text, self.query.redaction)
-            self.expensive_prompts.append(
-                {
+            row = self.expensive_prompts.get(prompt_hash)
+            if row is None:
+                row = {
                     "project": project,
                     "prompt_preview": preview,
                     "prompt_hash": prompt_hash,
                     "timestamp": timestamp,
-                    "total_tokens": total,
-                    "api_calls": 1,
+                    "total_tokens": 0,
+                    "api_calls": 0,
                     "subagent_type": context.subagent_type,
                     "slash_command": context.slash_command,
                     "skill": context.skill,
                     "redaction": self.query.redaction,
                 }
-            )
+                self.expensive_prompts[prompt_hash] = row
+            row["total_tokens"] = int(row["total_tokens"]) + total
+            row["api_calls"] = int(row["api_calls"]) + 1
         if usage["cache_creation_input_tokens"] > 0 and usage["cache_creation_input_tokens"] >= usage["cache_read_input_tokens"]:
             preview, prompt_hash = redact_prompt(context.text, self.query.redaction)
-            self.cache_breaks.append(
-                {
+            row = self.cache_breaks.get(prompt_hash)
+            if row is None:
+                row = {
                     "project": project,
                     "timestamp": timestamp,
                     "reason": "cache_creation_spike_after_prompt_change",
-                    "tokens": usage["cache_creation_input_tokens"],
+                    "tokens": 0,
+                    "api_calls": 0,
                     "prompt_hash": prompt_hash,
                     "prompt_preview": preview,
                 }
-            )
+                self.cache_breaks[prompt_hash] = row
+            row["tokens"] = int(row["tokens"]) + usage["cache_creation_input_tokens"]
+            row["api_calls"] = int(row["api_calls"]) + 1
 
     def _totals(self) -> dict[str, Any]:
         cache_total = self.totals.cache_read_input_tokens + self.totals.cache_creation_input_tokens
@@ -435,12 +442,50 @@ def aggregate_row(name: str, aggregate: Aggregate, total_tokens: int) -> dict[st
 
 def redact_prompt(prompt: str, redaction: str) -> tuple[str, str]:
     digest = "sha256:" + hashlib.sha256(prompt.encode("utf-8", errors="replace")).hexdigest()
+    normalized = normalize_prompt_preview(prompt)
     if redaction == "none":
         return prompt, digest
     if redaction == "summary":
-        return " ".join(prompt.split()[:12]), digest
-    compact = " ".join(prompt.split())
+        return " ".join(normalized.split()[:12]), digest
+    compact = " ".join(normalized.split())
     return (compact[:157] + "...") if len(compact) > 160 else compact, digest
+
+
+def normalize_prompt_preview(prompt: str) -> str:
+    compact = " ".join(prompt.split())
+    if compact.startswith("=== AGENT_CREW TASK ==="):
+        task_id = agent_crew_value(prompt, compact, "task_id")
+        task_type = agent_crew_value(prompt, compact, "task_type")
+        branch = agent_crew_value(prompt, compact, "branch")
+        label = "Agent Crew"
+        if task_type:
+            label += f" {task_type}"
+        if branch:
+            label += f" {branch}"
+        if task_id:
+            label += f" ({task_id})"
+        return label
+    channel_marker = '<channel source="plugin:' + "tele" + "gram:" + "tele" + "gram" + '"'
+    if compact.startswith(channel_marker):
+        message = regex_group(r">\s*(.*?)\s*</channel>", compact)
+        label = "Tele" + "gram"
+        return f"{label}: {message}" if message else f"{label} message"
+    return compact
+
+
+def agent_crew_value(prompt: str, compact: str, field: str) -> str | None:
+    line_match = re.search(rf"(?m)^[ \t]*{re.escape(field)}:[ \t]*(.*?)[ \t]*$", prompt)
+    value = line_match.group(1).strip() if line_match else None
+    if not value:
+        value = regex_group(rf"\b{re.escape(field)}:\s*([^\s]+)", compact)
+    if value in {"priority:", "context:", "description:", "result_url:"}:
+        return None
+    return value
+
+
+def regex_group(pattern: str, value: str) -> str | None:
+    match = re.search(pattern, value)
+    return match.group(1) if match else None
 
 
 def active_seconds(timestamps: list[int], gap_seconds: int) -> int:

--- a/tests/test_quota_core.py
+++ b/tests/test_quota_core.py
@@ -15,6 +15,7 @@ from quota_core.adapters.gemini import normalize_gemini_usage
 from quota_core.config import config_from_mapping, load_config, validate_config, write_default_config
 from quota_core.runtime import runtime_env
 from quota_core.session import analyze_claude_sessions, build_empty_session_report, normalize_session_report_query, validate_session_report_dict
+from quota_core.session.claude import normalize_prompt_preview
 from quota_core.snapshot import AggregateBreakdown, NormalizedSnapshot, RuntimeBreakdown, SnapshotWindow, snapshot_to_dict, validate_snapshot_dict
 from quota_core.cli import scan_config, write_dashboard, write_demo, write_scan
 from quota_core.dashboard.renderer import render_page
@@ -832,16 +833,83 @@ class SessionReportContractTests(unittest.TestCase):
         self.assertIn("/investigate why cache", report["expensive_prompts"][0]["prompt_preview"])
         self.assertEqual(report["reconciliation"]["quota_scanner_total_tokens"], 120)
 
+    def test_claude_session_parser_aggregates_prompt_diagnostics(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            project_dir = Path(temp_dir) / "demo-project"
+            project_dir.mkdir()
+            prompt = """
+=== AGENT_CREW TASK ===
+task_id: impl-abc123
+task_type: implement
+branch: main
+priority: 3
+context: {"instructions": "Write tests first"}
+""".strip()
+            rows = [
+                {"timestamp": "2026-05-07T00:00:00Z", "message": {"role": "user", "content": prompt}},
+                {
+                    "timestamp": "2026-05-07T00:00:01Z",
+                    "requestId": "req-1",
+                    "message": {
+                        "model": "claude-sonnet-4-6",
+                        "usage": {
+                            "input_tokens": 10,
+                            "output_tokens": 20,
+                            "cache_read_input_tokens": 0,
+                            "cache_creation_input_tokens": 40,
+                        },
+                    },
+                },
+                {
+                    "timestamp": "2026-05-07T00:00:02Z",
+                    "requestId": "req-2",
+                    "message": {
+                        "model": "claude-sonnet-4-6",
+                        "usage": {
+                            "input_tokens": 1,
+                            "output_tokens": 2,
+                            "cache_read_input_tokens": 0,
+                            "cache_creation_input_tokens": 4,
+                        },
+                    },
+                },
+            ]
+            (project_dir / "session.jsonl").write_text("\n".join(json.dumps(row) for row in rows) + "\n")
+
+            report = analyze_claude_sessions([temp_dir], since="24h", redaction="preview", now=1778169600)
+
+        self.assertEqual(len(report["expensive_prompts"]), 1)
+        self.assertEqual(report["expensive_prompts"][0]["total_tokens"], 77)
+        self.assertEqual(report["expensive_prompts"][0]["api_calls"], 2)
+        self.assertEqual(report["expensive_prompts"][0]["prompt_preview"], "Agent Crew implement main (impl-abc123)")
+        self.assertEqual(len(report["cache_breaks"]), 1)
+        self.assertEqual(report["cache_breaks"][0]["tokens"], 44)
+        self.assertEqual(report["cache_breaks"][0]["api_calls"], 2)
+
+    def test_claude_session_prompt_preview_handles_empty_agent_crew_branch(self):
+        prompt = """
+=== AGENT_CREW TASK ===
+task_id: claude-b8c39e06
+task_type: discuss
+branch:
+priority: 3
+""".strip()
+        self.assertEqual(normalize_prompt_preview(prompt), "Agent Crew discuss (claude-b8c39e06)")
+
     def test_dashboard_renders_claude_session_report(self):
         report = build_empty_session_report(generated_at=1770000000)
         report["totals"].update({"total_tokens": 300, "input_tokens": 100, "output_tokens": 80, "cache_read_input_tokens": 90, "cache_creation_input_tokens": 30, "cache_hit_pct": 75.0})
         report["by_project"] = [{"name": "demo-project", "display_name": "demo-project", "total_tokens": 300, "share_pct": 100.0}]
-        report["expensive_prompts"] = [{"prompt_preview": "expensive prompt", "total_tokens": 300}]
+        report["expensive_prompts"] = [{"project": "demo-project", "prompt_preview": "expensive prompt", "total_tokens": 300, "api_calls": 3}]
+        report["cache_breaks"] = [{"project": "demo-project", "prompt_preview": "cache prompt", "tokens": 120, "api_calls": 2}]
         snapshot = NormalizedSnapshot(source="claude", sampled_at=1770000000, history={"claude_session_report": report})
         page = render_page([snapshot])
         self.assertIn("Claude Sessions", page)
         self.assertIn("demo-project", page)
         self.assertIn("expensive prompt", page)
+        self.assertIn("300 · 3 calls", page)
+        self.assertIn("cache prompt", page)
+        self.assertIn("120 · 2 calls", page)
 
 
 class PublicSplitGuardTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- aggregate expensive prompt and cache-break diagnostics by prompt hash
- normalize Agent Crew and channel prompt previews into readable labels
- render project context and API call counts in the Claude Sessions panel

## Tests
- /home/truhojun/.pyenv/versions/3.12.9/bin/python -m pytest tests/test_quota_core.py -q
- cd /home/truhojun/alfred/quota && PYTHONPATH=/home/truhojun/alfred/quota /home/truhojun/.pyenv/versions/3.12.9/bin/python -m pytest tests/test_quota_core.py tests/test_private_runtime_aggregation.py -q

## Dashboard verification
- regenerated full snapshot and HTML via the canonical private ops path
- verified served dashboard returns 200 and no longer renders raw AGENT_CREW headers in Claude Sessions