### PR TITLE
Group Claude session diagnostics by prompt family

### DIFF
--- a/quota_core/dashboard/components.py
+++ b/quota_core/dashboard/components.py
@@ -247,7 +247,9 @@ def expensive_prompt_rows(rows: object) -> str:
         tokens = compact_number(int(row.get("total_tokens") or 0))
         project = str(row.get("project") or "unknown")
         calls = int(row.get("api_calls") or 0)
-        right = f"{tokens}{f' · {calls} calls' if calls else ''}"
+        variants = int(row.get("prompt_variants") or 0)
+        variant_text = f" · {variants} prompts" if variants > 1 else ""
+        right = f"{tokens}{f' · {calls} calls' if calls else ''}{variant_text}"
         items.append(f'<li><span>{html.escape(project)} · {html.escape(preview)}</span><strong>{html.escape(right)}</strong></li>')
     return f'<article class="session-card session-card-wide"><h3>Expensive Prompts</h3><ol class="runtime-project-list">{"".join(items)}</ol></article>' if items else ""
 
@@ -263,7 +265,9 @@ def cache_break_rows(rows: object) -> str:
         project = str(row.get("project") or "unknown")
         tokens = compact_number(int(row.get("tokens") or 0))
         calls = int(row.get("api_calls") or 0)
-        right = f"{tokens}{f' · {calls} calls' if calls else ''}"
+        variants = int(row.get("prompt_variants") or 0)
+        variant_text = f" · {variants} prompts" if variants > 1 else ""
+        right = f"{tokens}{f' · {calls} calls' if calls else ''}{variant_text}"
         items.append(f'<li><span>{html.escape(project)} · {html.escape(preview)}</span><strong>{html.escape(right)}</strong></li>')
     return f'<article class="session-card session-card-wide"><h3>Cache Breaks</h3><ol class="runtime-project-list">{"".join(items)}</ol></article>' if items else ""
 

--- a/quota_core/session/claude.py
+++ b/quota_core/session/claude.py
@@ -138,8 +138,8 @@ class ClaudeSessionScanner:
             by_subagent=self._rows(self.by_subagent),
             by_skill=self._rows(self.by_skill),
             by_slash_command=self._rows(self.by_slash_command),
-            expensive_prompts=sorted(self.expensive_prompts.values(), key=lambda row: -int(row["total_tokens"]))[:20],
-            cache_breaks=sorted(self.cache_breaks.values(), key=lambda row: -int(row["tokens"]))[:20],
+            expensive_prompts=sorted(diagnostic_rows(self.expensive_prompts), key=lambda row: -int(row["total_tokens"]))[:20],
+            cache_breaks=sorted(diagnostic_rows(self.cache_breaks), key=lambda row: -int(row["tokens"]))[:20],
             runtime_attribution=self._runtime_attribution(),
             reconciliation=self._reconciliation(),
             warnings=self.warnings,
@@ -230,12 +230,15 @@ class ClaudeSessionScanner:
         total = usage_total(usage)
         if context.text:
             preview, prompt_hash = redact_prompt(context.text, self.query.redaction)
-            row = self.expensive_prompts.get(prompt_hash)
+            family_key = prompt_family_key(project, context.text, prompt_hash)
+            row = self.expensive_prompts.get(family_key)
             if row is None:
                 row = {
                     "project": project,
                     "prompt_preview": preview,
                     "prompt_hash": prompt_hash,
+                    "prompt_family": family_key,
+                    "_prompt_hashes": set(),
                     "timestamp": timestamp,
                     "total_tokens": 0,
                     "api_calls": 0,
@@ -244,12 +247,14 @@ class ClaudeSessionScanner:
                     "skill": context.skill,
                     "redaction": self.query.redaction,
                 }
-                self.expensive_prompts[prompt_hash] = row
+                self.expensive_prompts[family_key] = row
+            row["_prompt_hashes"].add(prompt_hash)
             row["total_tokens"] = int(row["total_tokens"]) + total
             row["api_calls"] = int(row["api_calls"]) + 1
         if usage["cache_creation_input_tokens"] > 0 and usage["cache_creation_input_tokens"] >= usage["cache_read_input_tokens"]:
             preview, prompt_hash = redact_prompt(context.text, self.query.redaction)
-            row = self.cache_breaks.get(prompt_hash)
+            family_key = prompt_family_key(project, context.text, prompt_hash)
+            row = self.cache_breaks.get(family_key)
             if row is None:
                 row = {
                     "project": project,
@@ -258,9 +263,12 @@ class ClaudeSessionScanner:
                     "tokens": 0,
                     "api_calls": 0,
                     "prompt_hash": prompt_hash,
+                    "prompt_family": family_key,
+                    "_prompt_hashes": set(),
                     "prompt_preview": preview,
                 }
-                self.cache_breaks[prompt_hash] = row
+                self.cache_breaks[family_key] = row
+            row["_prompt_hashes"].add(prompt_hash)
             row["tokens"] = int(row["tokens"]) + usage["cache_creation_input_tokens"]
             row["api_calls"] = int(row["api_calls"]) + 1
 
@@ -440,6 +448,16 @@ def aggregate_row(name: str, aggregate: Aggregate, total_tokens: int) -> dict[st
     }
 
 
+def diagnostic_rows(rows: dict[str, dict[str, Any]]) -> list[dict[str, Any]]:
+    result = []
+    for row in rows.values():
+        cleaned = dict(row)
+        hashes = cleaned.pop("_prompt_hashes", set())
+        cleaned["prompt_variants"] = len(hashes) if isinstance(hashes, set) else 1
+        result.append(cleaned)
+    return result
+
+
 def redact_prompt(prompt: str, redaction: str) -> tuple[str, str]:
     digest = "sha256:" + hashlib.sha256(prompt.encode("utf-8", errors="replace")).hexdigest()
     normalized = normalize_prompt_preview(prompt)
@@ -453,6 +471,8 @@ def redact_prompt(prompt: str, redaction: str) -> tuple[str, str]:
 
 def normalize_prompt_preview(prompt: str) -> str:
     compact = " ".join(prompt.split())
+    if compact == "Poll agent_crew for next task and execute it.":
+        return "Agent Crew task polling"
     if compact.startswith("=== AGENT_CREW TASK ==="):
         task_id = agent_crew_value(prompt, compact, "task_id")
         task_type = agent_crew_value(prompt, compact, "task_type")
@@ -462,8 +482,6 @@ def normalize_prompt_preview(prompt: str) -> str:
             label += f" {task_type}"
         if branch:
             label += f" {branch}"
-        if task_id:
-            label += f" ({task_id})"
         return label
     channel_marker = '<channel source="plugin:' + "tele" + "gram:" + "tele" + "gram" + '"'
     if compact.startswith(channel_marker):
@@ -471,6 +489,17 @@ def normalize_prompt_preview(prompt: str) -> str:
         label = "Tele" + "gram"
         return f"{label}: {message}" if message else f"{label} message"
     return compact
+
+
+def prompt_family_key(project: str, prompt: str, prompt_hash: str) -> str:
+    compact = " ".join(prompt.split())
+    if compact == "Poll agent_crew for next task and execute it.":
+        return f"{project}:agent-crew:poll"
+    if compact.startswith("=== AGENT_CREW TASK ==="):
+        task_type = agent_crew_value(prompt, compact, "task_type") or "task"
+        branch = agent_crew_value(prompt, compact, "branch") or "no-branch"
+        return f"{project}:agent-crew:{task_type}:{branch}"
+    return f"{project}:{prompt_hash}"
 
 
 def agent_crew_value(prompt: str, compact: str, field: str) -> str | None:

--- a/tests/test_quota_core.py
+++ b/tests/test_quota_core.py
@@ -881,7 +881,8 @@ context: {"instructions": "Write tests first"}
         self.assertEqual(len(report["expensive_prompts"]), 1)
         self.assertEqual(report["expensive_prompts"][0]["total_tokens"], 77)
         self.assertEqual(report["expensive_prompts"][0]["api_calls"], 2)
-        self.assertEqual(report["expensive_prompts"][0]["prompt_preview"], "Agent Crew implement main (impl-abc123)")
+        self.assertEqual(report["expensive_prompts"][0]["prompt_preview"], "Agent Crew implement main")
+        self.assertEqual(report["expensive_prompts"][0]["prompt_variants"], 1)
         self.assertEqual(len(report["cache_breaks"]), 1)
         self.assertEqual(report["cache_breaks"][0]["tokens"], 44)
         self.assertEqual(report["cache_breaks"][0]["api_calls"], 2)
@@ -894,22 +895,67 @@ task_type: discuss
 branch:
 priority: 3
 """.strip()
-        self.assertEqual(normalize_prompt_preview(prompt), "Agent Crew discuss (claude-b8c39e06)")
+        self.assertEqual(normalize_prompt_preview(prompt), "Agent Crew discuss")
+
+    def test_claude_session_parser_groups_agent_crew_task_families(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            project_dir = Path(temp_dir) / "demo-project"
+            project_dir.mkdir()
+            rows = []
+            for index, task_id in enumerate(("impl-one", "impl-two"), start=1):
+                rows.extend(
+                    [
+                        {
+                            "timestamp": f"2026-05-07T00:00:0{index}Z",
+                            "message": {
+                                "role": "user",
+                                "content": f"""
+=== AGENT_CREW TASK ===
+task_id: {task_id}
+task_type: implement
+branch: main
+priority: 3
+""".strip(),
+                            },
+                        },
+                        {
+                            "timestamp": f"2026-05-07T00:00:1{index}Z",
+                            "requestId": f"req-{index}",
+                            "message": {
+                                "model": "claude-sonnet-4-6",
+                                "usage": {
+                                    "input_tokens": 10,
+                                    "output_tokens": 20,
+                                    "cache_read_input_tokens": 0,
+                                    "cache_creation_input_tokens": 40,
+                                },
+                            },
+                        },
+                    ]
+                )
+            (project_dir / "session.jsonl").write_text("\n".join(json.dumps(row) for row in rows) + "\n")
+
+            report = analyze_claude_sessions([temp_dir], since="24h", redaction="preview", now=1778169600)
+
+        self.assertEqual(len(report["expensive_prompts"]), 1)
+        self.assertEqual(report["expensive_prompts"][0]["prompt_preview"], "Agent Crew implement main")
+        self.assertEqual(report["expensive_prompts"][0]["prompt_variants"], 2)
+        self.assertEqual(report["expensive_prompts"][0]["api_calls"], 2)
 
     def test_dashboard_renders_claude_session_report(self):
         report = build_empty_session_report(generated_at=1770000000)
         report["totals"].update({"total_tokens": 300, "input_tokens": 100, "output_tokens": 80, "cache_read_input_tokens": 90, "cache_creation_input_tokens": 30, "cache_hit_pct": 75.0})
         report["by_project"] = [{"name": "demo-project", "display_name": "demo-project", "total_tokens": 300, "share_pct": 100.0}]
-        report["expensive_prompts"] = [{"project": "demo-project", "prompt_preview": "expensive prompt", "total_tokens": 300, "api_calls": 3}]
-        report["cache_breaks"] = [{"project": "demo-project", "prompt_preview": "cache prompt", "tokens": 120, "api_calls": 2}]
+        report["expensive_prompts"] = [{"project": "demo-project", "prompt_preview": "expensive prompt", "total_tokens": 300, "api_calls": 3, "prompt_variants": 2}]
+        report["cache_breaks"] = [{"project": "demo-project", "prompt_preview": "cache prompt", "tokens": 120, "api_calls": 2, "prompt_variants": 2}]
         snapshot = NormalizedSnapshot(source="claude", sampled_at=1770000000, history={"claude_session_report": report})
         page = render_page([snapshot])
         self.assertIn("Claude Sessions", page)
         self.assertIn("demo-project", page)
         self.assertIn("expensive prompt", page)
-        self.assertIn("300 · 3 calls", page)
+        self.assertIn("300 · 3 calls · 2 prompts", page)
         self.assertIn("cache prompt", page)
-        self.assertIn("120 · 2 calls", page)
+        self.assertIn("120 · 2 calls · 2 prompts", page)
 
 
 class PublicSplitGuardTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- group Claude expensive-prompt and cache-break diagnostics by prompt family instead of task-specific prompt hash
- collapse Agent Crew task IDs into readable labels like `Agent Crew implement main`
- show distinct prompt counts in the dashboard rows so grouped automation bursts are visible without row spam

## Tests
- /home/truhojun/.pyenv/versions/3.12.9/bin/python -m pytest tests/test_quota_core.py -q
- cd /home/truhojun/alfred/quota && PYTHONPATH=/home/truhojun/alfred/quota /home/truhojun/.pyenv/versions/3.12.9/bin/python -m pytest tests/test_quota_core.py tests/test_private_runtime_aggregation.py -q

## Dashboard verification
- regenerated full snapshot and HTML via the canonical private ops path
- verified served dashboard returns 200
- verified task IDs no longer appear in Claude Sessions rows and prompt family grouping is visible